### PR TITLE
json 内にコメントを記述したかったので yaml から一度コンバートする形式を取る

### DIFF
--- a/SETUP.md
+++ b/SETUP.md
@@ -1,0 +1,33 @@
+manifest.json は json なのでコメントアウトができない
+
+そこで、yaml から変換することで yaml 側でコメントアウトして対処できるようにする
+
+そのために yq (yaml > json 変換コマンド) を入れる
+
+```sh
+brew install python-yq
+```
+
+python3.9 を入れるために xcode-select を入れるよう指示されるケースがあるのでその場合は指示に従う
+
+```sh
+xcode-select
+```
+
+特に指定がなかったり上記インストールができていてシェルがリフレッシュできていれば yq が使えるようになる
+
+yq で template.yaml から manifest.json に変換する
+
+コマンドは以下の通り
+
+```sh
+yq . template.yaml > manifest.json
+```
+
+第一引数のドットは全てを意味する
+
+もし一部だけ出力したい場合は以下のように指定すると、 name プロパティ配下の内容を manifest.json に書き出すことも可能
+
+```sh
+yq .name .template.yaml > manifest.json
+```

--- a/manifest.json
+++ b/manifest.json
@@ -5,12 +5,20 @@
   "manifest_version": 3,
   "content_scripts": [
     {
-      "js": ["github_project_assignee_list.js"],
-      "matches": ["https://github.com/*"]
+      "js": [
+        "github_project_assignee_list.js"
+      ],
+      "matches": [
+        "https://github.com/*"
+      ]
     },
     {
-      "js": ["observe_youtube_watch.js"],
-      "matches": ["https://www.youtube.com/*"]
+      "js": [
+        "observe_youtube_watch.js"
+      ],
+      "matches": [
+        "https://www.youtube.com/*"
+      ]
     }
   ]
 }

--- a/template.yaml
+++ b/template.yaml
@@ -1,0 +1,13 @@
+name: "amabie chrome extension"
+description: "天日江護が使うchrome拡張機能"
+version: "1.0"
+manifest_version: 3
+content_scripts:
+  - js:
+      - "github_project_assignee_list.js"
+    matches:
+      - "https://github.com/*"
+  - js:
+      - "observe_youtube_watch.js"
+    matches:
+      - "https://www.youtube.com/*"


### PR DESCRIPTION
json はコメントアウトができない

そのため、一部機能を一時的に廃止したい場合に全削除しかできない

また、削除しないように chrome-extention 側に実装を施すには今の知識量だとすぐに実装できるか判断できなかった

そこで、 yaml から json に build してから使う形式にすることで yaml 上ではコメントできるのでこの問題を解決するようにした

manifest.json に差分こそあるものの、内容は変わっていないことがわかる（改行の都合で差分がでている）